### PR TITLE
Support flat media saving

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,15 @@ npm install
 python main.py
 ```
 
+### 保存选项 (save_choice)
+- `all`：保存excel和媒体文件
+- `excel`：仅保存excel
+- `media`：保存视频和图片
+- `media-image`：仅保存图片
+- `media-video`：仅保存视频
+- `image-flat`：图集直接保存在 `media` 路径下，文件名为 `<note_id>_<index>.jpg`
+- `video-flat`：视频直接保存在 `media` 路径下，文件名为 `<note_id>.mp4`
+
 ### 🗝️注意事项
 - main.py中的代码是爬虫的入口，可以根据自己的需求进行修改
 - apis/xhs_pc_apis.py 中的代码包含了所有的api接口，可以根据自己的需求进行修改

--- a/main.py
+++ b/main.py
@@ -46,7 +46,7 @@ class Data_Spider():
             if note_info is not None and success:
                 note_list.append(note_info)
         for note_info in note_list:
-            if save_choice == 'all' or 'media' in save_choice:
+            if save_choice == 'all' or 'media' in save_choice or 'flat' in save_choice:
                 download_note(note_info, base_path['media'], save_choice)
         if save_choice == 'all' or save_choice == 'excel':
             file_path = os.path.abspath(os.path.join(base_path['excel'], f'{excel_name}.xlsx'))
@@ -121,7 +121,12 @@ if __name__ == '__main__':
     cookies_str, base_path = init()
     data_spider = Data_Spider()
     """
-        save_choice: all: 保存所有的信息, media: 保存视频和图片（media-video只下载视频, media-image只下载图片，media都下载）, excel: 保存到excel
+        save_choice 说明:
+        - all: 保存所有的信息
+        - media: 保存视频和图片（media-video只下载视频, media-image只下载图片，media都下载）
+        - image-flat: 图集直接保存在media路径下，文件名为<note_id>_<index>.jpg
+        - video-flat: 视频直接保存在media路径下，文件名为<note_id>.mp4
+        - excel: 仅保存到excel
         save_choice 为 excel 或者 all 时，excel_name 不能为空
     """
 

--- a/xhs_utils/data_util.py
+++ b/xhs_utils/data_util.py
@@ -256,11 +256,21 @@ def download_note(note_info, path, save_choice):
     nickname = norm_str(nickname)[:20]
     if title.strip() == '':
         title = f'无标题'
+    note_type = note_info['note_type']
+
+    # flat mode: directly store media under base path
+    if save_choice == 'image-flat' and note_type == '图集':
+        for img_index, img_url in enumerate(note_info['image_list']):
+            download_media(path, f"{note_id}_{img_index}", img_url, 'image')
+        return path
+    if save_choice == 'video-flat' and note_type == '视频':
+        download_media(path, note_id, note_info['video_addr'], 'video')
+        return path
+
     save_path = f'{path}/{nickname}_{user_id}/{title}_{note_id}'
     check_and_create_path(save_path)
     with open(f'{save_path}/info.json', mode='w', encoding='utf-8') as f:
         f.write(json.dumps(note_info) + '\n')
-    note_type = note_info['note_type']
     save_note_detail(note_info, save_path)
     if note_type == '图集' and save_choice in ['media', 'media-image', 'all']:
         for img_index, img_url in enumerate(note_info['image_list']):


### PR DESCRIPTION
## Summary
- download_note: add `image-flat` and `video-flat` save choices
- spider_some_note: trigger downloads for new flat modes
- document new `save_choice` options in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6847537be83483309b5a3fbeb063d725