### PR TITLE
Add video transcoding support

### DIFF
--- a/main.py
+++ b/main.py
@@ -30,7 +30,7 @@ class Data_Spider():
         logger.info(f'爬取笔记信息 {note_url}: {success}, msg: {msg}')
         return success, msg, note_info
 
-    def spider_some_note(self, notes: list, cookies_str: str, base_path: dict, save_choice: str, excel_name: str = '', proxies=None):
+    def spider_some_note(self, notes: list, cookies_str: str, base_path: dict, save_choice: str, excel_name: str = '', transcode=False, proxies=None):
         """
         爬取一些笔记的信息
         :param notes:
@@ -47,13 +47,13 @@ class Data_Spider():
                 note_list.append(note_info)
         for note_info in note_list:
             if save_choice == 'all' or 'media' in save_choice:
-                download_note(note_info, base_path['media'], save_choice)
+                download_note(note_info, base_path['media'], save_choice, transcode)
         if save_choice == 'all' or save_choice == 'excel':
             file_path = os.path.abspath(os.path.join(base_path['excel'], f'{excel_name}.xlsx'))
             save_to_xlsx(note_list, file_path)
 
 
-    def spider_user_all_note(self, user_url: str, cookies_str: str, base_path: dict, save_choice: str, excel_name: str = '', proxies=None):
+    def spider_user_all_note(self, user_url: str, cookies_str: str, base_path: dict, save_choice: str, excel_name: str = '', transcode=False, proxies=None):
         """
         爬取一个用户的所有笔记
         :param user_url:
@@ -71,14 +71,14 @@ class Data_Spider():
                     note_list.append(note_url)
             if save_choice == 'all' or save_choice == 'excel':
                 excel_name = user_url.split('/')[-1].split('?')[0]
-            self.spider_some_note(note_list, cookies_str, base_path, save_choice, excel_name, proxies)
+            self.spider_some_note(note_list, cookies_str, base_path, save_choice, excel_name, transcode, proxies)
         except Exception as e:
             success = False
             msg = e
         logger.info(f'爬取用户所有视频 {user_url}: {success}, msg: {msg}')
         return note_list, success, msg
 
-    def spider_some_search_note(self, query: str, require_num: int, cookies_str: str, base_path: dict, save_choice: str, sort_type_choice=0, note_type=0, note_time=0, note_range=0, pos_distance=0, geo: dict = None,  excel_name: str = '', proxies=None):
+    def spider_some_search_note(self, query: str, require_num: int, cookies_str: str, base_path: dict, save_choice: str, sort_type_choice=0, note_type=0, note_time=0, note_range=0, pos_distance=0, geo: dict = None,  excel_name: str = '', transcode=False, proxies=None):
         """
             指定数量搜索笔记，设置排序方式和笔记类型和笔记数量
             :param query 搜索的关键词
@@ -103,7 +103,7 @@ class Data_Spider():
                     note_list.append(note_url)
             if save_choice == 'all' or save_choice == 'excel':
                 excel_name = query
-            self.spider_some_note(note_list, cookies_str, base_path, save_choice, excel_name, proxies)
+            self.spider_some_note(note_list, cookies_str, base_path, save_choice, excel_name, transcode, proxies)
         except Exception as e:
             success = False
             msg = e


### PR DESCRIPTION
## Summary
- add `transcode_to_h264` helper to convert videos with ffmpeg
- allow optional transcoding in note downloading and search helpers

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6847538185ec83309bc613ba93891dc5