### PR TITLE
Add progress bars and threaded media downloads

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ loguru
 python-dotenv
 retry
 openpyxl
+tqdm


### PR DESCRIPTION
## Summary
- display progress with `tqdm` when processing note lists and downloading media
- parallelize image downloads using `ThreadPoolExecutor`
- record failed downloads and allow retry
- update dependencies

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`
- `pip install -r requirements.txt`

------
https://chatgpt.com/codex/tasks/task_e_6847538855f083309ac40a52f3b6df94