### PR TITLE
Add video transcoding

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,9 @@ python main.py
 - `image-flat`：图集直接保存在 `media` 路径下，文件名为 `<note_id>_<index>.jpg`
 - `video-flat`：视频直接保存在 `media` 路径下，文件名为 `<note_id>.mp4`
 
+### 额外参数
+- `transcode`：将下载的视频转码为 H.264 编码，需要本地安装 `ffmpeg`
+
 ### 🗝️注意事项
 - main.py中的代码是爬虫的入口，可以根据自己的需求进行修改
 - apis/xhs_pc_apis.py 中的代码包含了所有的api接口，可以根据自己的需求进行修改

--- a/main.py
+++ b/main.py
@@ -30,7 +30,7 @@ class Data_Spider():
         logger.info(f'爬取笔记信息 {note_url}: {success}, msg: {msg}')
         return success, msg, note_info
 
-    def spider_some_note(self, notes: list, cookies_str: str, base_path: dict, save_choice: str, excel_name: str = '', proxies=None):
+    def spider_some_note(self, notes: list, cookies_str: str, base_path: dict, save_choice: str, excel_name: str = '', proxies=None, transcode: bool = False):
         """
         爬取一些笔记的信息
         :param notes:
@@ -47,13 +47,13 @@ class Data_Spider():
                 note_list.append(note_info)
         for note_info in note_list:
             if save_choice == 'all' or 'media' in save_choice or 'flat' in save_choice:
-                download_note(note_info, base_path['media'], save_choice)
+                download_note(note_info, base_path['media'], save_choice, transcode)
         if save_choice == 'all' or save_choice == 'excel':
             file_path = os.path.abspath(os.path.join(base_path['excel'], f'{excel_name}.xlsx'))
             save_to_xlsx(note_list, file_path)
 
 
-    def spider_user_all_note(self, user_url: str, cookies_str: str, base_path: dict, save_choice: str, excel_name: str = '', proxies=None):
+    def spider_user_all_note(self, user_url: str, cookies_str: str, base_path: dict, save_choice: str, excel_name: str = '', proxies=None, transcode: bool = False):
         """
         爬取一个用户的所有笔记
         :param user_url:
@@ -71,14 +71,14 @@ class Data_Spider():
                     note_list.append(note_url)
             if save_choice == 'all' or save_choice == 'excel':
                 excel_name = user_url.split('/')[-1].split('?')[0]
-            self.spider_some_note(note_list, cookies_str, base_path, save_choice, excel_name, proxies)
+            self.spider_some_note(note_list, cookies_str, base_path, save_choice, excel_name, proxies, transcode)
         except Exception as e:
             success = False
             msg = e
         logger.info(f'爬取用户所有视频 {user_url}: {success}, msg: {msg}')
         return note_list, success, msg
 
-    def spider_some_search_note(self, query: str, require_num: int, cookies_str: str, base_path: dict, save_choice: str, sort_type_choice=0, note_type=0, note_time=0, note_range=0, pos_distance=0, geo: dict = None,  excel_name: str = '', proxies=None):
+    def spider_some_search_note(self, query: str, require_num: int, cookies_str: str, base_path: dict, save_choice: str, sort_type_choice=0, note_type=0, note_time=0, note_range=0, pos_distance=0, geo: dict = None,  excel_name: str = '', proxies=None, transcode: bool = False):
         """
             指定数量搜索笔记，设置排序方式和笔记类型和笔记数量
             :param query 搜索的关键词
@@ -103,7 +103,7 @@ class Data_Spider():
                     note_list.append(note_url)
             if save_choice == 'all' or save_choice == 'excel':
                 excel_name = query
-            self.spider_some_note(note_list, cookies_str, base_path, save_choice, excel_name, proxies)
+            self.spider_some_note(note_list, cookies_str, base_path, save_choice, excel_name, proxies, transcode)
         except Exception as e:
             success = False
             msg = e


### PR DESCRIPTION
## Summary
- add optional ffmpeg-based `transcode_to_h264` helper
- expose `transcode` flag on spider operations
- document how to enable video transcoding

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `npm test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684754f6188c8330888b9609cb2ef7eb