### PR TITLE
Add pytest suite and CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,15 @@
+name: CI
+
+on: [push, pull_request]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - uses: actions/setup-python@v5
+      with:
+        python-version: '3.12'
+    - run: pip install -r requirements.txt
+    - run: pip install pytest pytest-cov
+    - run: pytest -q --cov=xhs_utils --cov=apis --cov-report=xml

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,8 @@ python-dotenv
 retry
 openpyxl
 tqdm
+pytest
+pytest-cov
+requests-mock
+respx
+freezegun

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,18 @@
+import json
+import os
+from pathlib import Path
+
+import pytest
+
+
+def fake_resp(file_name: str) -> dict:
+    base = Path(__file__).resolve().parent / "static"
+    with open(base / file_name, "r", encoding="utf-8") as f:
+        return json.load(f)
+
+
+@pytest.fixture
+def patch_env(monkeypatch, tmp_path):
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("COOKIES", "a=1;b=2")
+    yield

--- a/tests/integration/test_main_flow.py
+++ b/tests/integration/test_main_flow.py
@@ -1,0 +1,44 @@
+import sys, pathlib; sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[2]))
+from main import Data_Spider
+
+
+def test_spider_note(monkeypatch):
+    spider = Data_Spider()
+    sample = {
+        "data": {
+            "items": [
+                {
+                    "id": "n1",
+                    "url": "http://x.com/n1",
+                    "note_card": {
+                        "type": "normal",
+                        "user": {
+                            "user_id": "u1",
+                            "nickname": "nick",
+                            "avatar": "a.jpg",
+                        },
+                        "title": "title",
+                        "desc": "desc",
+                        "interact_info": {
+                            "liked_count": 1,
+                            "collected_count": 2,
+                            "comment_count": 3,
+                            "share_count": 4,
+                        },
+                        "image_list": [{"info_list": [{}, {"url": "img.jpg"}]}],
+                        "tag_list": [{"name": "tag"}],
+                        "time": 1609459200000,
+                    },
+                }
+            ]
+        }
+    }
+
+    def fake_get(note_url, cookies, proxies=None):
+        return True, "ok", sample
+
+    monkeypatch.setattr(spider.xhs_apis, "get_note_info", fake_get)
+    success, msg, info = spider.spider_note("http://x.com/n1", "c")
+    assert success
+    assert info["note_id"] == "n1"
+    assert info["note_type"] == "图集"

--- a/tests/unit/test_common_util.py
+++ b/tests/unit/test_common_util.py
@@ -1,0 +1,75 @@
+import sys, pathlib; sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[2]))
+import requests_mock
+
+from xhs_utils.data_util import (
+    norm_str,
+    timestamp_to_str,
+    check_and_create_path,
+    save_failed,
+    retry_failed,
+    download_media,
+)
+from xhs_utils.cookie_util import trans_cookies
+from xhs_utils.xhs_util import generate_x_b3_traceid, splice_str
+
+
+def test_norm_str():
+    text = "inva/\\lid:*?<>|\n name"
+    cleaned = norm_str(text)
+    assert '/' not in cleaned and '*' not in cleaned and '\n' not in cleaned
+
+
+def test_timestamp_to_str():
+    ts = 1609459200000  # 2021-01-01 00:00:00
+    assert timestamp_to_str(ts) == "2021-01-01 00:00:00"
+
+
+def test_trans_cookies():
+    cookies = trans_cookies("a=1; b=2")
+    assert cookies == {"a": "1", "b": "2"}
+    cookies = trans_cookies("a=1;b=2")
+    assert cookies == {"a": "1", "b": "2"}
+
+
+def test_generate_x_b3_traceid():
+    trace = generate_x_b3_traceid(16)
+    assert len(trace) == 16
+    int(trace, 16)
+
+
+def test_splice_str():
+    url = splice_str("/api", {"a": "1", "b": "2"})
+    assert url == "/api?a=1&b=2"
+
+
+def test_check_and_create_path(tmp_path):
+    target = tmp_path / "newdir"
+    check_and_create_path(target)
+    assert target.exists()
+
+
+def test_save_and_retry_failed(tmp_path):
+    file_path = tmp_path / "failed.txt"
+    save_failed([{"path": "p", "name": "n", "url": "u", "type": "image"}], file_path)
+    records = retry_failed(file_path)
+    assert records[0]["name"] == "n"
+
+
+def test_download_media_image(tmp_path):
+    url = "http://example.com/img.jpg"
+    with requests_mock.Mocker() as m:
+        m.get(url, content=b"data")
+        result = download_media(str(tmp_path), "img", url, "image")
+    assert result
+    assert (tmp_path / "img.jpg").exists()
+
+
+def test_download_media_video(tmp_path):
+    url = "http://example.com/video.mp4"
+    content = b"\x00\x00\x00\x18ftypmp42"  # minimal mp4 header
+    with requests_mock.Mocker() as m:
+        m.get(url, content=content)
+        result = download_media(str(tmp_path), "vid", url, "video")
+    assert result
+    assert (tmp_path / "vid.mp4").exists()
+


### PR DESCRIPTION
## Summary
- set up unit test framework with pytest
- add sample tests for utility functions and main spider logic
- provide GitHub Actions workflow for running tests
- include testing dependencies in requirements

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68475d5f03348330b91babea6df81906