### PR TITLE
Add Typer CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,13 @@ To obtain your cookie:
 python main.py
 ```
 
+### Command Line Interface
+Install dependencies and run:
+```bash
+python cli.py crawl --cookie "<your_cookie>" --note-id "<note_id>"
+```
+See `python cli.py --help` for all commands.
+
 ### Search and Download
 ```bash
 python main.py --query "keyword" --num 5 --save-choice all --excel-name output

--- a/cli.py
+++ b/cli.py
@@ -1,0 +1,27 @@
+import typer
+from main import Data_Spider
+from xhs_utils.common_util import init
+
+app = typer.Typer(help="XHS Spider command line interface")
+
+@app.command()
+def version() -> None:
+    """Show tool version."""
+    typer.echo("xhs-spider 0.1")
+
+@app.command()
+def crawl(cookie: str = typer.Option(..., help="Xiaohongshu cookie"),
+          note_id: str = typer.Option(..., help="Note ID to crawl")):
+    """Crawl a single note."""
+    _, base_path = init()
+    spider = Data_Spider()
+    note_url = f"https://www.xiaohongshu.com/explore/{note_id}"
+    success, msg, info = spider.spider_note(note_url, cookie)
+    if success:
+        typer.echo(f"Crawled {note_id} successfully")
+    else:
+        typer.echo(f"Failed: {msg}")
+        raise typer.Exit(code=1)
+
+if __name__ == "__main__":
+    app()

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,3 +10,4 @@ pytest-cov
 requests-mock
 respx
 freezegun
+typer

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -1,0 +1,18 @@
+import sys, pathlib
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[2]))
+from typer.testing import CliRunner
+from cli import app
+from main import Data_Spider
+
+runner = CliRunner()
+
+def test_cli_help():
+    result = runner.invoke(app, ["--help"])
+    assert "Usage" in result.stdout
+
+def test_cli_crawl(monkeypatch):
+    def fake_spider(self, url, cookie, proxies=None):
+        return True, "ok", {"id": "n1"}
+    monkeypatch.setattr(Data_Spider, "spider_note", fake_spider)
+    result = runner.invoke(app, ["crawl", "--cookie", "c", "--note-id", "n1"])
+    assert "Crawled n1 successfully" in result.stdout


### PR DESCRIPTION
## Summary
- add Typer-based CLI with `crawl` subcommand
- document CLI usage in README
- test new CLI behaviour
- include `typer` in requirements

## Testing
- `pip install -r requirements.txt`
- `npm ci`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6847670436688330b590d89e042e9a00