### PR TITLE
Fix timestamp and search bugs

### DIFF
--- a/apis/pc/search.py
+++ b/apis/pc/search.py
@@ -134,6 +134,9 @@ class SearchAPI(BaseAPI):
             success, msg = False, str(e)
         if len(note_list) > require_num:
             note_list = note_list[:require_num]
+        if success and not note_list:
+            success = False
+            msg = f'No results for "{query}"'
         return success, msg, note_list
 
     def search_user(self, query: str, cookies_str: str, page: int = 1, proxies: Dict[str, str] | None = None) -> Tuple[bool, str, Any]:

--- a/main.py
+++ b/main.py
@@ -105,13 +105,28 @@ class Data_Spider():
         """
         note_list = []
         try:
-            success, msg, notes = self.xhs_apis.search_some_note(query, require_num, cookies_str, sort_type_choice, note_type, note_time, note_range, pos_distance, geo, proxies)
+            success, msg, notes = self.xhs_apis.search_some_note(
+                query,
+                require_num,
+                cookies_str,
+                sort_type_choice,
+                note_type,
+                note_time,
+                note_range,
+                pos_distance,
+                geo,
+                proxies,
+            )
             if success:
                 notes = list(filter(lambda x: x['model_type'] == "note", notes))
-                logger.info(f'搜索关键词 {query} 笔记数量: {len(notes)}')
-                for note in tqdm(notes, desc="notes"):
-                    note_url = f"https://www.xiaohongshu.com/explore/{note['id']}?xsec_token={note['xsec_token']}"
-                    note_list.append(note_url)
+                if not notes:
+                    success = False
+                    msg = f'No results for "{query}"'
+                else:
+                    logger.info(f'搜索关键词 {query} 笔记数量: {len(notes)}')
+                    for note in tqdm(notes, desc="notes"):
+                        note_url = f"https://www.xiaohongshu.com/explore/{note['id']}?xsec_token={note['xsec_token']}"
+                        note_list.append(note_url)
             if save_choice == 'all' or save_choice == 'excel':
                 excel_name = query
             self.spider_some_note(note_list, cookies_str, base_path, save_choice, excel_name, proxies, transcode)

--- a/tests/unit/test_common_util.py
+++ b/tests/unit/test_common_util.py
@@ -1,5 +1,8 @@
 import sys, pathlib; sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[2]))
 import requests_mock
+import os
+import time
+import pytest
 
 from xhs_utils.data_util import (
     norm_str,
@@ -74,4 +77,17 @@ def test_download_media_video(tmp_path):
         result = download_media(str(tmp_path), "vid", url, "video")
     assert result
     assert (tmp_path / "vid.mp4").exists()
+
+
+def test_timestamp_negative():
+    with pytest.raises(ValueError):
+        timestamp_to_str(-1000)
+
+
+def test_timestamp_timezone_independent(monkeypatch):
+    monkeypatch.setenv("TZ", "Asia/Shanghai")
+    if hasattr(time, "tzset"):
+        time.tzset()
+    ts = 1609459200000  # 2021-01-01 00:00:00 UTC
+    assert timestamp_to_str(ts) == "2021-01-01 00:00:00"
 

--- a/xhs_utils/data_util.py
+++ b/xhs_utils/data_util.py
@@ -26,9 +26,11 @@ def norm_text(text):
 
 
 def timestamp_to_str(timestamp):
-    time_local = time.localtime(timestamp / 1000)
-    dt = time.strftime("%Y-%m-%d %H:%M:%S", time_local)
-    return dt
+    """Return UTC time string from millisecond timestamp."""
+    if timestamp < 0:
+        raise ValueError("timestamp must be non-negative")
+    time_utc = time.gmtime(timestamp / 1000)
+    return time.strftime("%Y-%m-%d %H:%M:%S", time_utc)
 
 def handle_user_info(data, user_id):
     home_url = f'https://www.xiaohongshu.com/user/profile/{user_id}'


### PR DESCRIPTION
## Summary
- handle negative timestamps and use UTC
- detect empty search results
- ensure CLI search message for empty results
- test negative timestamps and timezone independence

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68478178e9f08330b8151e8414c9e6a7