### PR TITLE
Fix cookie parsing and add rate limiting

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ python main.py --help
 
 - **Python** 3.7 or higher
 - **Node.js** 18.0 or higher
+- **jsdom** (installed via `npm install`) for DOM emulation
 - **Operating System**: Windows, macOS, or Linux
 - **Memory**: 4GB RAM minimum (8GB recommended)
 - **Storage**: Varies based on media download requirements
@@ -216,6 +217,8 @@ python main.py \
   --rate-limit 2 \
   --retry 3
 ```
+
+`--rate-limit` sets the minimum number of seconds to wait between HTTP requests.
 
 ### Save Options Explained
 

--- a/apis/pc/base.py
+++ b/apis/pc/base.py
@@ -1,3 +1,34 @@
+"""Base classes and helpers for API modules."""
+
+import time
+import requests
+
+
 class BaseAPI:
-    def __init__(self) -> None:
+    def __init__(self, rate_limit: float = 0.0) -> None:
+        """Initialize the API helper.
+
+        Parameters
+        ----------
+        rate_limit: float
+            Minimum seconds to wait between requests. ``0`` disables the delay.
+        """
+
         self.base_url = "https://edith.xiaohongshu.com"
+        self.rate_limit = rate_limit
+        self._last_request = 0.0
+
+    def _sleep_if_needed(self) -> None:
+        if self.rate_limit > 0:
+            elapsed = time.time() - self._last_request
+            if elapsed < self.rate_limit:
+                time.sleep(self.rate_limit - elapsed)
+        self._last_request = time.time()
+
+    def _get(self, *args, **kwargs):
+        self._sleep_if_needed()
+        return requests.get(*args, **kwargs)
+
+    def _post(self, *args, **kwargs):
+        self._sleep_if_needed()
+        return requests.post(*args, **kwargs)

--- a/apis/pc/comment.py
+++ b/apis/pc/comment.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 from typing import Tuple, List, Dict, Any
 import urllib
-import requests
 from xhs_utils.xhs_util import splice_str, generate_request_params
 from .base import BaseAPI
 
@@ -28,7 +27,7 @@ class CommentAPI(BaseAPI):
             }
             splice_api = splice_str(api, params)
             headers, cookies, _ = generate_request_params(cookies_str, splice_api)
-            response = requests.get(self.base_url + splice_api, headers=headers, cookies=cookies, proxies=proxies)
+            response = self._get(self.base_url + splice_api, headers=headers, cookies=cookies, proxies=proxies)
             res_json = response.json()
             success, msg = res_json["success"], res_json["msg"]
         except Exception as e:
@@ -82,7 +81,7 @@ class CommentAPI(BaseAPI):
             }
             splice_api = splice_str(api, params)
             headers, cookies, _ = generate_request_params(cookies_str, splice_api)
-            response = requests.get(self.base_url + splice_api, headers=headers, cookies=cookies, proxies=proxies)
+            response = self._get(self.base_url + splice_api, headers=headers, cookies=cookies, proxies=proxies)
             res_json = response.json()
             success, msg = res_json["success"], res_json["msg"]
         except Exception as e:
@@ -141,7 +140,7 @@ class CommentAPI(BaseAPI):
         try:
             api = "/api/sns/web/unread_count"
             headers, cookies, _ = generate_request_params(cookies_str, api)
-            response = requests.get(self.base_url + api, headers=headers, cookies=cookies, proxies=proxies)
+            response = self._get(self.base_url + api, headers=headers, cookies=cookies, proxies=proxies)
             res_json = response.json()
             success, msg = res_json["success"], res_json["msg"]
         except Exception as e:
@@ -156,7 +155,7 @@ class CommentAPI(BaseAPI):
             params = {"num": "20", "cursor": cursor}
             splice_api = splice_str(api, params)
             headers, cookies, _ = generate_request_params(cookies_str, splice_api)
-            response = requests.get(self.base_url + splice_api, headers=headers, cookies=cookies, proxies=proxies)
+            response = self._get(self.base_url + splice_api, headers=headers, cookies=cookies, proxies=proxies)
             res_json = response.json()
             success, msg = res_json["success"], res_json["msg"]
         except Exception as e:
@@ -189,7 +188,7 @@ class CommentAPI(BaseAPI):
             params = {"num": "20", "cursor": cursor}
             splice_api = splice_str(api, params)
             headers, cookies, _ = generate_request_params(cookies_str, splice_api)
-            response = requests.get(self.base_url + splice_api, headers=headers, cookies=cookies, proxies=proxies)
+            response = self._get(self.base_url + splice_api, headers=headers, cookies=cookies, proxies=proxies)
             res_json = response.json()
             success, msg = res_json["success"], res_json["msg"]
         except Exception as e:
@@ -222,7 +221,7 @@ class CommentAPI(BaseAPI):
             params = {"num": "20", "cursor": cursor}
             splice_api = splice_str(api, params)
             headers, cookies, _ = generate_request_params(cookies_str, splice_api)
-            response = requests.get(self.base_url + splice_api, headers=headers, cookies=cookies, proxies=proxies)
+            response = self._get(self.base_url + splice_api, headers=headers, cookies=cookies, proxies=proxies)
             res_json = response.json()
             success, msg = res_json["success"], res_json["msg"]
         except Exception as e:

--- a/apis/pc/detail.py
+++ b/apis/pc/detail.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 from typing import Tuple, List, Dict, Any
 import urllib
 import re
-import requests
 from xhs_utils.xhs_util import splice_str, generate_request_params, get_common_headers
 from .base import BaseAPI
 
@@ -16,7 +15,7 @@ class DetailAPI(BaseAPI):
             params = {"target_user_id": user_id}
             splice_api = splice_str(api, params)
             headers, cookies, _ = generate_request_params(cookies_str, splice_api)
-            response = requests.get(self.base_url + splice_api, headers=headers, cookies=cookies, proxies=proxies)
+            response = self._get(self.base_url + splice_api, headers=headers, cookies=cookies, proxies=proxies)
             res_json = response.json()
             success, msg = res_json["success"], res_json["msg"]
         except Exception as e:
@@ -29,7 +28,7 @@ class DetailAPI(BaseAPI):
         try:
             api = "/api/sns/web/v1/user/selfinfo"
             headers, cookies, _ = generate_request_params(cookies_str, api)
-            response = requests.get(self.base_url + api, headers=headers, cookies=cookies, proxies=proxies)
+            response = self._get(self.base_url + api, headers=headers, cookies=cookies, proxies=proxies)
             res_json = response.json()
             success, msg = res_json["success"], res_json["msg"]
         except Exception as e:
@@ -42,7 +41,7 @@ class DetailAPI(BaseAPI):
         try:
             api = "/api/sns/web/v2/user/me"
             headers, cookies, _ = generate_request_params(cookies_str, api)
-            response = requests.get(self.base_url + api, headers=headers, cookies=cookies, proxies=proxies)
+            response = self._get(self.base_url + api, headers=headers, cookies=cookies, proxies=proxies)
             res_json = response.json()
             success, msg = res_json["success"], res_json["msg"]
         except Exception as e:
@@ -72,7 +71,7 @@ class DetailAPI(BaseAPI):
             }
             splice_api = splice_str(api, params)
             headers, cookies, _ = generate_request_params(cookies_str, splice_api)
-            response = requests.get(self.base_url + splice_api, headers=headers, cookies=cookies, proxies=proxies)
+            response = self._get(self.base_url + splice_api, headers=headers, cookies=cookies, proxies=proxies)
             res_json = response.json()
             success, msg = res_json["success"], res_json["msg"]
         except Exception as e:
@@ -125,7 +124,7 @@ class DetailAPI(BaseAPI):
             }
             splice_api = splice_str(api, params)
             headers, cookies, _ = generate_request_params(cookies_str, splice_api)
-            response = requests.get(self.base_url + splice_api, headers=headers, cookies=cookies, proxies=proxies)
+            response = self._get(self.base_url + splice_api, headers=headers, cookies=cookies, proxies=proxies)
             res_json = response.json()
             success, msg = res_json["success"], res_json["msg"]
         except Exception as e:
@@ -178,7 +177,7 @@ class DetailAPI(BaseAPI):
             }
             splice_api = splice_str(api, params)
             headers, cookies, _ = generate_request_params(cookies_str, splice_api)
-            response = requests.get(self.base_url + splice_api, headers=headers, cookies=cookies, proxies=proxies)
+            response = self._get(self.base_url + splice_api, headers=headers, cookies=cookies, proxies=proxies)
             res_json = response.json()
             success, msg = res_json["success"], res_json["msg"]
         except Exception as e:
@@ -224,7 +223,7 @@ class DetailAPI(BaseAPI):
                 "xsec_token": kv_dist["xsec_token"],
             }
             headers, cookies, data = generate_request_params(cookies_str, api, data)
-            response = requests.post(self.base_url + api, headers=headers, data=data, cookies=cookies, proxies=proxies)
+            response = self._post(self.base_url + api, headers=headers, data=data, cookies=cookies, proxies=proxies)
             res_json = response.json()
             success, msg = res_json["success"], res_json["msg"]
         except Exception as e:
@@ -240,7 +239,7 @@ class DetailAPI(BaseAPI):
         try:
             headers = get_common_headers()
             url = f"https://www.xiaohongshu.com/explore/{note_id}"
-            response = requests.get(url, headers=headers)
+            response = self._get(url, headers=headers)
             res = response.text
             video_addr = re.findall(r'<meta name="og:video" content="(.*?)">', res)[0]
         except Exception as e:

--- a/apis/pc/feed.py
+++ b/apis/pc/feed.py
@@ -1,5 +1,4 @@
 from typing import Tuple, List, Dict, Any
-import requests
 from xhs_utils.xhs_util import generate_request_params
 from .base import BaseAPI
 
@@ -11,7 +10,7 @@ class FeedAPI(BaseAPI):
         try:
             api = "/api/sns/web/v1/homefeed/category"
             headers, cookies, _ = generate_request_params(cookies_str, api)
-            response = requests.get(self.base_url + api, headers=headers, cookies=cookies, proxies=proxies)
+            response = self._get(self.base_url + api, headers=headers, cookies=cookies, proxies=proxies)
             res_json = response.json()
             success, msg = res_json["success"], res_json["msg"]
         except Exception as e:
@@ -46,7 +45,7 @@ class FeedAPI(BaseAPI):
                 "need_filter_image": False,
             }
             headers, cookies, trans_data = generate_request_params(cookies_str, api, data)
-            response = requests.post(
+            response = self._post(
                 self.base_url + api,
                 headers=headers,
                 data=trans_data,

--- a/apis/pc/search.py
+++ b/apis/pc/search.py
@@ -1,7 +1,6 @@
 from typing import Tuple, List, Dict, Any
 import json
 import urllib
-import requests
 from xhs_utils.xhs_util import splice_str, generate_request_params, generate_x_b3_traceid
 from .base import BaseAPI
 
@@ -38,7 +37,7 @@ class SearchAPI(BaseAPI):
             params = {"keyword": urllib.parse.quote(word)}
             splice_api = splice_str(api, params)
             headers, cookies, _ = generate_request_params(cookies_str, splice_api)
-            response = requests.get(self.base_url + splice_api, headers=headers, cookies=cookies, proxies=proxies)
+            response = self._get(self.base_url + splice_api, headers=headers, cookies=cookies, proxies=proxies)
             res_json = response.json()
             success, msg = res_json["success"], res_json["msg"]
         except Exception as e:
@@ -78,7 +77,7 @@ class SearchAPI(BaseAPI):
                 "image_formats": ["jpg", "webp", "avif"],
             }
             headers, cookies, data = generate_request_params(cookies_str, api, data)
-            response = requests.post(
+            response = self._post(
                 self.base_url + api,
                 headers=headers,
                 data=data.encode("utf-8"),
@@ -152,7 +151,7 @@ class SearchAPI(BaseAPI):
                 }
             }
             headers, cookies, data = generate_request_params(cookies_str, api, data)
-            response = requests.post(
+            response = self._post(
                 self.base_url + api,
                 headers=headers,
                 data=data.encode("utf-8"),

--- a/apis/xhs_pc_apis.py
+++ b/apis/xhs_pc_apis.py
@@ -3,6 +3,6 @@ from .pc import FeedAPI, SearchAPI, DetailAPI, CommentAPI
 
 
 class XHS_Apis(FeedAPI, SearchAPI, DetailAPI, CommentAPI):
-    def __init__(self) -> None:
-        super().__init__()
+    def __init__(self, rate_limit: float = 0.0) -> None:
+        super().__init__(rate_limit)
 

--- a/cli.py
+++ b/cli.py
@@ -10,11 +10,19 @@ def version() -> None:
     typer.echo("xhs-spider 0.1")
 
 @app.command()
-def crawl(cookie: str = typer.Option(..., help="Xiaohongshu cookie"),
-          note_id: str = typer.Option(..., help="Note ID to crawl")):
+def crawl(
+    cookie: str = typer.Option(..., help="Xiaohongshu cookie"),
+    note_id: str = typer.Option(..., help="Note ID to crawl"),
+    rate_limit: float = typer.Option(0.0, help="Delay between requests in seconds"),
+):
     """Crawl a single note."""
+    if not cookie.strip():
+        raise typer.BadParameter("cookie cannot be empty")
+    if not note_id.strip() or len(note_id) > 64:
+        raise typer.BadParameter("note-id is invalid")
+
     _, base_path = init()
-    spider = Data_Spider()
+    spider = Data_Spider(rate_limit=rate_limit)
     note_url = f"https://www.xiaohongshu.com/explore/{note_id}"
     success, msg, info = spider.spider_note(note_url, cookie)
     if success:

--- a/main.py
+++ b/main.py
@@ -16,8 +16,9 @@ from tqdm import tqdm
 
 
 class Data_Spider():
-    def __init__(self):
-        self.xhs_apis = XHS_Apis()
+    def __init__(self, rate_limit: float = 0.0):
+        """Initialize spider with optional request rate limiting."""
+        self.xhs_apis = XHS_Apis(rate_limit=rate_limit)
 
     def spider_note(self, note_url: str, cookies_str: str, proxies=None):
         """
@@ -177,10 +178,13 @@ def cli():
     parser.add_argument("--pos-distance", type=int, default=0)
     parser.add_argument("--transcode", action="store_true")
     parser.add_argument("--retry-failed", action="store_true", help="retry failed downloads")
+    parser.add_argument("--rate-limit", type=float, default=0.0, help="delay between requests in seconds")
     args = parser.parse_args()
 
     cookies_str, base_path = init()
-    spider = Data_Spider()
+    if args.rate_limit < 0:
+        parser.error("--rate-limit must be non-negative")
+    spider = Data_Spider(rate_limit=args.rate_limit)
 
     if args.retry_failed:
         records = retry_failed("failed.txt")

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -16,3 +16,9 @@ def test_cli_crawl(monkeypatch):
     monkeypatch.setattr(Data_Spider, "spider_note", fake_spider)
     result = runner.invoke(app, ["crawl", "--cookie", "c", "--note-id", "n1"])
     assert "Crawled n1 successfully" in result.stdout
+
+
+def test_cli_validation(monkeypatch):
+    result = runner.invoke(app, ["crawl", "--cookie", "", "--note-id", ""])
+    assert result.exit_code != 0
+    assert "note-id is invalid" in result.stderr or "cookie cannot be empty" in result.stderr

--- a/tests/unit/test_common_util.py
+++ b/tests/unit/test_common_util.py
@@ -31,6 +31,7 @@ def test_trans_cookies():
     assert cookies == {"a": "1", "b": "2"}
     cookies = trans_cookies("a=1;b=2")
     assert cookies == {"a": "1", "b": "2"}
+    assert trans_cookies("") == {}
 
 
 def test_generate_x_b3_traceid():

--- a/tests/unit/test_rate_limit.py
+++ b/tests/unit/test_rate_limit.py
@@ -1,0 +1,11 @@
+import time
+from apis.pc.base import BaseAPI
+
+
+def test_rate_limiting():
+    api = BaseAPI(rate_limit=0.1)
+    start = time.time()
+    api._sleep_if_needed()  # first call
+    api._sleep_if_needed()  # second call should wait
+    assert time.time() - start >= 0.1
+

--- a/xhs_utils/cookie_util.py
+++ b/xhs_utils/cookie_util.py
@@ -1,6 +1,22 @@
-def trans_cookies(cookies_str):
-    if '; ' in cookies_str:
-        ck = {i.split('=')[0]: '='.join(i.split('=')[1:]) for i in cookies_str.split('; ')}
-    else:
-        ck = {i.split('=')[0]: '='.join(i.split('=')[1:]) for i in cookies_str.split(';')}
+"""Utility helpers for cookie handling."""
+
+
+def trans_cookies(cookies_str: str) -> dict:
+    """Translate a cookie string into a dictionary.
+
+    Empty values return an empty dict instead of ``{"": ""}``.
+    ``cookies_str`` may use either ``;`` or ``; `` as separators.
+    """
+
+    cookies_str = cookies_str.strip()
+    if not cookies_str:
+        return {}
+
+    separator = "; " if "; " in cookies_str else ";"
+    ck = {}
+    for item in cookies_str.split(separator):
+        if not item or "=" not in item:
+            continue
+        key, value = item.split("=", 1)
+        ck[key] = value
     return ck


### PR DESCRIPTION
## Summary
- handle empty cookie strings in `trans_cookies`
- introduce rate limiting helpers
- allow passing rate limit from CLI
- validate CLI inputs
- document jsdom and rate limit usage
- add unit tests for new utilities

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684781cc0fd08330a7502f2865506dfd