### PR TITLE
Add note ID validation in CLI

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -1,6 +1,15 @@
+import re
 import typer
 from main import Data_Spider
 from xhs_utils.common_util import init
+
+
+def validate_note_id(value: str) -> str:
+    """Validate note ID format."""
+    pattern = r"^[0-9a-f]{24}$"
+    if not value or not re.fullmatch(pattern, value.strip()):
+        raise typer.BadParameter("note-id is invalid")
+    return value
 
 app = typer.Typer(help="XHS Spider command line interface")
 
@@ -12,14 +21,12 @@ def version() -> None:
 @app.command()
 def crawl(
     cookie: str = typer.Option(..., help="Xiaohongshu cookie"),
-    note_id: str = typer.Option(..., help="Note ID to crawl"),
+    note_id: str = typer.Option(..., help="Note ID to crawl", callback=validate_note_id),
     rate_limit: float = typer.Option(0.0, help="Delay between requests in seconds"),
 ):
     """Crawl a single note."""
     if not cookie.strip():
         raise typer.BadParameter("cookie cannot be empty")
-    if not note_id.strip() or len(note_id) > 64:
-        raise typer.BadParameter("note-id is invalid")
 
     _, base_path = init()
     spider = Data_Spider(rate_limit=rate_limit)

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -14,11 +14,24 @@ def test_cli_crawl(monkeypatch):
     def fake_spider(self, url, cookie, proxies=None):
         return True, "ok", {"id": "n1"}
     monkeypatch.setattr(Data_Spider, "spider_note", fake_spider)
-    result = runner.invoke(app, ["crawl", "--cookie", "c", "--note-id", "n1"])
-    assert "Crawled n1 successfully" in result.stdout
+    note_id = "a" * 24
+    result = runner.invoke(app, ["crawl", "--cookie", "c", "--note-id", note_id])
+    assert f"Crawled {note_id} successfully" in result.stdout
 
 
 def test_cli_validation(monkeypatch):
     result = runner.invoke(app, ["crawl", "--cookie", "", "--note-id", ""])
     assert result.exit_code != 0
     assert "note-id is invalid" in result.stderr or "cookie cannot be empty" in result.stderr
+
+
+def test_invalid_note_id_short(monkeypatch):
+    result = runner.invoke(app, ["crawl", "--cookie", "c", "--note-id", "abc"])
+    assert result.exit_code != 0
+    assert "note-id is invalid" in result.stderr
+
+
+def test_invalid_note_id_path(monkeypatch):
+    result = runner.invoke(app, ["crawl", "--cookie", "c", "--note-id", "../../etc/passwd"])
+    assert result.exit_code != 0
+    assert "note-id is invalid" in result.stderr


### PR DESCRIPTION
## Summary
- enforce strict note ID format in `cli.py`
- add invalid ID callback using Typer
- expand CLI tests to cover invalid note IDs

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68478464b86483309b015241d99646bc