### PR TITLE
Handle missing note items

### DIFF
--- a/main.py
+++ b/main.py
@@ -37,9 +37,15 @@ class Data_Spider():
         try:
             success, msg, note_info = self.xhs_apis.get_note_info(note_url, cookies_str, proxies)
             if success:
-                note_info = note_info['data']['items'][0]
-                note_info['url'] = note_url
-                note_info = handle_note_info(note_info)
+                items = note_info.get('data', {}).get('items', [])
+                if not items:
+                    success = False
+                    msg = 'note not found or authentication failed'
+                    note_info = None
+                else:
+                    note_info = items[0]
+                    note_info['url'] = note_url
+                    note_info = handle_note_info(note_info)
         except Exception as e:
             success = False
             msg = e

--- a/tests/unit/test_regressions.py
+++ b/tests/unit/test_regressions.py
@@ -63,3 +63,16 @@ def test_save_to_xlsx_creates_dir(tmp_path):
     file_path = tmp_path / 'newdir' / 'file.xlsx'
     save_to_xlsx([sample_note()], str(file_path))
     assert file_path.exists()
+
+
+def test_empty_items_returns_failure(monkeypatch):
+    spider = Data_Spider()
+
+    def fake_get(note_url, cookies_str, proxies=None):
+        return True, 'ok', {'data': {'items': []}}
+
+    monkeypatch.setattr(spider.xhs_apis, 'get_note_info', fake_get)
+    success, msg, info = spider.spider_note('http://x.com/n1', 'c')
+    assert not success
+    assert 'not found' in msg
+    assert info is None


### PR DESCRIPTION
## Summary
- handle empty `items` from API in spider
- add regression test for empty item list

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6847846af0ac83309c642010eac281a2