### PR TITLE
Add note-url option for crawl command

### DIFF
--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -7,10 +7,10 @@ from main import Data_Spider
 runner = CliRunner()
 
 def test_cli_help():
-    result = runner.invoke(app, ["--help"])
-    assert "Usage" in result.stdout
+    result = runner.invoke(app, ["crawl", "--help"])
+    assert "--note-url" in result.stdout
 
-def test_cli_crawl(monkeypatch):
+def test_cli_crawl_with_id(monkeypatch):
     def fake_spider(self, url, cookie, proxies=None):
         return True, "ok", {"id": "n1"}
     monkeypatch.setattr(Data_Spider, "spider_note", fake_spider)
@@ -18,7 +18,23 @@ def test_cli_crawl(monkeypatch):
     assert "Crawled n1 successfully" in result.stdout
 
 
+def test_cli_crawl_with_url(monkeypatch):
+    def fake_spider(self, url, cookie, proxies=None):
+        assert url == "http://x.com/n1"
+        return True, "ok", {"id": "n1"}
+
+    monkeypatch.setattr(Data_Spider, "spider_note", fake_spider)
+    result = runner.invoke(app, ["crawl", "--cookie", "c", "--note-url", "http://x.com/n1"])
+    assert "Crawled http://x.com/n1 successfully" in result.stdout
+
+
 def test_cli_validation(monkeypatch):
+    # empty cookie and missing identifiers
     result = runner.invoke(app, ["crawl", "--cookie", "", "--note-id", ""])
     assert result.exit_code != 0
     assert "note-id is invalid" in result.stderr or "cookie cannot be empty" in result.stderr
+
+    # valid cookie but no id or url
+    result = runner.invoke(app, ["crawl", "--cookie", "c", "--note-id", ""]) 
+    assert result.exit_code != 0
+    assert "note-id is invalid" in result.stderr


### PR DESCRIPTION
## Summary
- support `--note-url` option for CLI crawl command
- recommend using full note URL when available
- extend tests for new crawl behaviour

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6847846965708330b5e6196d21892247