### PR TITLE
Add env cookie fallback

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -1,3 +1,4 @@
+import os
 import typer
 from main import Data_Spider
 from xhs_utils.common_util import init
@@ -11,12 +12,16 @@ def version() -> None:
 
 @app.command()
 def crawl(
-    cookie: str = typer.Option(..., help="Xiaohongshu cookie"),
+    cookie: str | None = typer.Option(
+        None, help="Xiaohongshu cookie"
+    ),
     note_id: str = typer.Option(..., help="Note ID to crawl"),
     rate_limit: float = typer.Option(0.0, help="Delay between requests in seconds"),
 ):
     """Crawl a single note."""
-    if not cookie.strip():
+    if cookie is None:
+        cookie = os.getenv("COOKIES")
+    if not cookie or not cookie.strip():
         raise typer.BadParameter("cookie cannot be empty")
     if not note_id.strip() or len(note_id) > 64:
         raise typer.BadParameter("note-id is invalid")

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -18,6 +18,18 @@ def test_cli_crawl(monkeypatch):
     assert "Crawled n1 successfully" in result.stdout
 
 
+def test_cli_env_cookie(monkeypatch):
+    monkeypatch.setenv("COOKIES", "envc")
+
+    def fake_spider(self, url, cookie, proxies=None):
+        assert cookie == "envc"
+        return True, "ok", {"id": "n1"}
+
+    monkeypatch.setattr(Data_Spider, "spider_note", fake_spider)
+    result = runner.invoke(app, ["crawl", "--note-id", "n1"])
+    assert "Crawled n1 successfully" in result.stdout
+
+
 def test_cli_validation(monkeypatch):
     result = runner.invoke(app, ["crawl", "--cookie", "", "--note-id", ""])
     assert result.exit_code != 0


### PR DESCRIPTION
## Summary
- support getting cookie from `COOKIES` env var when --cookie isn't passed
- test cli uses env var as cookie

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684784669cd483308d2267208c362ba9