### PR TITLE
Fix cookie env var reading

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,13 +136,15 @@ npm install
 
 ### 3. Configuration
 
-```bash
-# Copy example configuration
-cp .env.example .env
+Create a `.env` file in the project root and provide your authentication
+cookie. The code reads the value from the `COOKIES` environment variable but
+`XHS_COOKIE` is also supported for compatibility.
 
-# Edit .env file with your settings
-# Required: XHS_COOKIE
-# Optional: PROXY_URL, OUTPUT_DIR, etc.
+```bash
+# .env
+COOKIES="your_cookie_value_here"
+# or
+XHS_COOKIE="your_cookie_value_here"
 ```
 
 ## 🔐 Authentication
@@ -235,7 +237,7 @@ Spider_XHS/
 ├── cli.py                  # Command-line interface
 ├── requirements.txt        # Python dependencies
 ├── package.json           # Node.js dependencies
-├── .env.example           # Configuration template
+├── .env                  # Environment variables
 ├── LICENSE                # MIT License
 ├── README.md              # This file
 ├── apis/                  # API modules

--- a/xhs_utils/common_util.py
+++ b/xhs_utils/common_util.py
@@ -4,7 +4,7 @@ from dotenv import load_dotenv
 
 def load_env():
     load_dotenv()
-    cookies_str = os.getenv('COOKIES')
+    cookies_str = os.getenv('COOKIES') or os.getenv('XHS_COOKIE')
     return cookies_str
 
 def init():


### PR DESCRIPTION
## Summary
- support `XHS_COOKIE` env var in addition to `COOKIES`
- document correct env var usage in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68479c5bbacc833087a974bc0fc63563